### PR TITLE
Add support for tracking slayer tasks assigned by Spria

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Turael Skipping
 author=BrastaSauce
 support=
 description=Displays best location and information for Turael tasks
-tags=turael,skipping,slayer,boosting
+tags=turael,skipping,slayer,boosting,tureal,spria
 plugins=com.brastasauce.turaelskipping.TuraelSkippingPlugin

--- a/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingPlugin.java
+++ b/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingPlugin.java
@@ -58,8 +58,8 @@ public class TuraelSkippingPlugin extends Plugin
 	private static final String SPRIA = "Spria";
 
 	// NPC messages
-	private static final Pattern TURAEL_ASSIGN_MESSAGE = Pattern.compile(".*(?:Your new task is to kill \\d+) (?<name>.+)(?:.)");
-	private static final Pattern TURAEL_CURRENT_MESSAGE = Pattern.compile(".*(?:You're still hunting) (?<name>.+)(?:, you have \\d+ to go.)");
+	private static final Pattern SLAYER_ASSIGN_MESSAGE = Pattern.compile(".*(?:Your new task is to kill \\d+) (?<name>.+)(?:.)");
+	private static final Pattern SLAYER_CURRENT_MESSAGE = Pattern.compile(".*(?:You're still hunting) (?<name>.+)(?:[,;] you have \\d+ to go.)");
 
 	private boolean worldPointSet = false;
 
@@ -115,8 +115,8 @@ public class TuraelSkippingPlugin extends Plugin
 		if (npcDialog != null && npcName != null && (npcName.getText().equals(TURAEL) || npcName.getText().equals(SPRIA)))
 		{
 			String npcText = Text.sanitizeMultilineText(npcDialog.getText());
-			final Matcher mAssign = TURAEL_ASSIGN_MESSAGE.matcher(npcText);
-			final Matcher mCurrent = TURAEL_CURRENT_MESSAGE.matcher(npcText);
+			final Matcher mAssign = SLAYER_ASSIGN_MESSAGE.matcher(npcText);
+			final Matcher mCurrent = SLAYER_CURRENT_MESSAGE.matcher(npcText);
 
 			if (mAssign.find())
 			{

--- a/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingPlugin.java
+++ b/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingPlugin.java
@@ -55,6 +55,7 @@ import java.util.regex.Pattern;
 public class TuraelSkippingPlugin extends Plugin
 {
 	private static final String TURAEL = "Turael";
+	private static final String SPRIA = "Spria";
 
 	// NPC messages
 	private static final Pattern TURAEL_ASSIGN_MESSAGE = Pattern.compile(".*(?:Your new task is to kill \\d+) (?<name>.+)(?:.)");
@@ -111,8 +112,7 @@ public class TuraelSkippingPlugin extends Plugin
 		// Getting tasks
 		Widget npcName = client.getWidget(WidgetInfo.DIALOG_NPC_NAME);
 		Widget npcDialog = client.getWidget(WidgetInfo.DIALOG_NPC_TEXT);
-
-		if (npcDialog != null && npcName.getText().equals(TURAEL))
+		if (npcDialog != null && npcName != null && (npcName.getText().equals(TURAEL) || npcName.getText().equals(SPRIA)))
 		{
 			String npcText = Text.sanitizeMultilineText(npcDialog.getText());
 			final Matcher mAssign = TURAEL_ASSIGN_MESSAGE.matcher(npcText);


### PR DESCRIPTION
Also checks if the Draynor Village's slayer master, Spria, is assigning a task.

While she can't replace a task like Turael, she's functionally the same otherwise; so she can still be used for point boosting.

I've also added the following tags:
- `spria`
- `tureal` (a likely misspelling of Turael)